### PR TITLE
Only commit when there are uncommitted changes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -23,16 +23,22 @@ function activate(context) {
         if (!branch.startsWith(branchPrefix)) {
           vscode.window.showErrorMessage(
             'Current branch "' +
-              branch.trim() +
-              '" is not a valid event branch.'
+            branch.trim() +
+            '" is not a valid event branch.'
           );
         } else {
           var commitMessage = 'Update at "' + new Date().toLocaleString() + '"';
-
-          runCommand("git add -A", () => {
-            runCommand("git commit -m '" + commitMessage + "'", () => {
+          runCommand("git status -s", (status) => {
+            if (status.length !== 0) {
+              runCommand("git add -A", () => {
+                runCommand("git commit -m '" + commitMessage + "'", () => {
+                  vscode.commands.executeCommand("wpilibcore.deployCode");
+                });
+              });
+            } else {
+              vscode.window.showInformationMessage("No new changes to commit");
               vscode.commands.executeCommand("wpilibcore.deployCode");
-            });
+            }
           });
         }
       });
@@ -42,7 +48,7 @@ function activate(context) {
 // @ts-ignore
 exports.activate = activate;
 
-function deactivate() {}
+function deactivate() { }
 
 module.exports = {
   activate,


### PR DESCRIPTION
If the `Deploy Robot Code (Event)` command is ran when there are no new changes to commit, it will send an info message to the user and deploy the robot code as normal. This prevents empty commits from being creates if the deploy command is run when no changes were made.