### PR TITLE
Add "Deploy Robot Code (Event)" to build.gradle context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,13 @@
 					"group": "wpilib@0",
 					"when": "isWPILibProject"
 				}
+			],
+			"explorer/context": [
+				{
+					"when": "resourceFilename == build.gradle && isWPILibProject",
+					"command": "event-deploy-wpilib.deploy",
+					"group": "wpilib@0"
+				}
 			]
 		}
 	},


### PR DESCRIPTION
Similar to how there's the "Deploy Robot Code" command when you right click on `build.gradle`, this adds the "Deploy Robot Code (Event)" command right under it